### PR TITLE
Add type declaration generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /dist
 /lib
 /es
+/types
 /*.tgz
 
 # Editor specifics

--- a/package.json
+++ b/package.json
@@ -5,18 +5,21 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "types": "types/index.d.ts",
   "files": [
     "dist",
     "lib",
-    "es"
+    "es",
+    "types"
   ],
   "scripts": {
-    "clean": "rimraf lib dist es coverage docs && mkdir docs",
-    "build": "npm run clean && npm run build:commonjs && npm run build:es && npm run build:umd && npm run build:umd:min && npm run build:docs",
+    "clean": "rimraf lib dist es types coverage docs && mkdir docs",
+    "build": "npm run clean && npm run build:commonjs && npm run build:es && npm run build:umd && npm run build:umd:min && npm run build:types && npm run build:docs",
     "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir lib",
     "build:es": "cross-env BABEL_ENV=es babel src --out-dir es",
     "build:umd": "cross-env BABEL_ENV=es NODE_ENV=development rollup src/index.js --config --sourcemap --file dist/modapp.js",
     "build:umd:min": "cross-env BABEL_ENV=es NODE_ENV=production rollup src/index.js --config --file dist/modapp.min.js",
+    "build:types": "tsc",
     "build:docs": "jsdoc2md -f ./src/class/App.js -f ./src/class/AppExt.js -f ./src/interface/AppModule.js -f ./src/interface/Component.js -f ./src/interface/Model.js -f ./src/interface/Collection.js -f ./src/interface/Readyable.js -f ./src/interface/LocaleString.js > ./docs/docs.md",
     "eslint": "eslint src/**/*.js",
     "jest": "jest src --coverage",
@@ -42,7 +45,8 @@
     "jsdoc-to-markdown": "^6.0.1",
     "rimraf": "^3.0.2",
     "rollup": "^2.79.1",
-    "rollup-plugin-terser": "^6.1.0"
+    "rollup-plugin-terser": "^6.1.0",
+    "typescript": "^5.0.4"
   },
   "dependencies": {
     "modapp-eventbus": "^1.8.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  // Change this to match your project
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    // Tells TypeScript to read JS files, as
+    // normally they are ignored as source files
+    "allowJs": true,
+    // Generate d.ts files
+    "declaration": true,
+    // This compiler run should
+    // only output d.ts files
+    "emitDeclarationOnly": true,
+    // Types should go into this directory.
+    // Removing this would place the .d.ts files
+    // next to the .js files
+    "outDir": "types",
+    // go to js file when using IDE functions like
+    // "Go to Definition" in VSCode
+    "declarationMap": true
+  }
+}


### PR DESCRIPTION
This adds typescript type declaration generation from existing JSDoc comments.
The generated type declaration files and map files will be included in the package, making vscode (and typescript) users happy.
